### PR TITLE
Proposed fix for fail reports by CPANTESTERS.

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -3,8 +3,8 @@
 use Test::More tests => 1;
 
 BEGIN {
-    use_ok( 'Convert::Base81' ) || print "Bail out!
+    use_ok( 'Convert::Base85' ) || print "Bail out!
 ";
 }
 
-diag( "Testing Convert::Base81 $Convert::Base81::VERSION, Perl $], $^X" );
+diag( "Testing Convert::Base85 $Convert::Base85::VERSION, Perl $], $^X" );

--- a/t/interface.t
+++ b/t/interface.t
@@ -5,28 +5,28 @@ use strict;
 
 use Test::More tests => 19;
 
-require_ok('Convert::Base81');
+require_ok('Convert::Base85');
 
-ok defined &Convert::Base81::encode;
-ok defined &Convert::Base81::decode;
+ok defined &Convert::Base85::encode;
+ok defined &Convert::Base85::decode;
 ok !defined &encode;
 ok !defined &decode;
-ok !defined &base81_encode;
-ok !defined &base81_decode;
+ok !defined &base85_encode;
+ok !defined &base85_decode;
 
-use_ok('Convert::Base81');
-
-ok !defined &encode;
-ok !defined &decode;
-ok !defined &base81_encode;
-ok !defined &base81_decode;
-
-use_ok('Convert::Base81', qw(base81_encode base81_decode));
+use_ok('Convert::Base85');
 
 ok !defined &encode;
 ok !defined &decode;
-ok defined &base81_encode;
-ok defined &base81_decode;
+ok !defined &base85_encode;
+ok !defined &base85_decode;
 
-ok \&base81_encode == \&Convert::Base81::encode;
-ok \&base81_decode == \&Convert::Base81::decode;
+use_ok('Convert::Base85', qw(base85_encode base85_decode));
+
+ok !defined &encode;
+ok !defined &decode;
+ok defined &base85_encode;
+ok defined &base85_decode;
+
+ok \&base85_encode == \&Convert::Base85::encode;
+ok \&base85_decode == \&Convert::Base85::decode;


### PR DESCRIPTION
Hi @jgamble 

Please review the PR.

https://www.cpantesters.org/cpan/report/bf882ba6-3412-11e9-b02d-fef01a328d68
https://www.cpantesters.org/cpan/report/c3feee18-3412-11e9-b02d-fef01a328d68

    #   Failed test 'use Convert::Base81;'
    #   at t/00-load.t line 6.
    #     Tried to use 'Convert::Base81'.
    #     Error:  Can't locate Convert/Base81.pm in @INC (you may need to install the Convert::Base81 module) (@INC contains: /home/cpansand/.cpan/build/2019021906/Convert-Base85-1.01-6VDp_v/blib/lib /home/cpansand/.cpan/build/2019021906/Convert-Base85-1.01-6VDp_v/blib/arch /home/cpansand/.cpan/build/2019021906/Math-Int128-0.22-LmWIne/blib/arch /home/cpansand/.cpan/build/2019021906/Math-Int128-0.22-LmWIne/blib/lib /home/cpansand/.cpan/build/2019021906/Math-Int64-0.54-lzPHdr/blib/arch /home/cpansand/.cpan/build/2019021906/Math-Int64-0.54-lzPHdr/blib/lib /home/cpansand/.cpan/build/2019021906/Math-Int128-0.22-LmWIne/blib/arch /home/cpansand/.cpan/build/2019021906/Math-Int128-0.22-LmWIne/blib/lib /home/cpansand/.cpan/build/2019021906/Math-Int64-0.54-lzPHdr/blib/arch /home/cpansand/.cpan/build/2019021906/Math-Int64-0.54-lzPHdr/blib/lib /opt/perl-5.18.4/lib/site_perl/5.18.4/x86_64-linux /opt/perl-5.18.4/lib/site_perl/5.18.4 /opt/perl-5.18.4/lib/5.18.4/x86_64-linux /opt/perl-5.18.4/lib/5.18.4) at t/00-load.t line 6.
    # BEGIN failed--compilation aborted at t/00-load.t line 6.
    Bailout called.  Further testing stopped:  
    # Testing Convert::Base81 , Perl 5.018004, /opt/perl-5.18.4/bin/perl
    # Looks like you failed 1 test of 1.
    FAILED--Further testing stopped.

Many Thanks.
Best Regards,
Mohammad S Anwar